### PR TITLE
Extend syntax highlighter

### DIFF
--- a/src/Gt4beam/BeamStylerUtilities.class.st
+++ b/src/Gt4beam/BeamStylerUtilities.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #BeamStylerUtilities,
+	#superclass : #Object,
+	#category : #Gt4beam
+}
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> colorAndHighlightParenthesesLeft: aLeftIndex right: aRightIndex atNestingLevel: aNestingLevel inText: aText leftLength: aLength [
+	self
+		highlightParenthesesLeft: aLeftIndex
+		right: aRightIndex
+		inText: aText.
+	self
+		colorParenthesesLeft: aLeftIndex
+		right: aRightIndex
+		atNestingLevel: aNestingLevel
+		inText: aText
+		leftLength: aLength
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> colorParenthesesLeft: aLeftIndex right: aRightIndex atNestingLevel: aNestingLevel inText: aText leftLength: aLength [
+	| color |
+	color := self parenthesesColorAt: aNestingLevel.
+	(aText from: aLeftIndex to: aLeftIndex + aLength) foreground: color.
+	(aText from: aRightIndex to: aRightIndex) foreground: color
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> highlightParenthesesLeft: aLeftIndex right: aRightIndex inText: aText [
+	| theParanthesesMarker cursorEnterAction cursorLeaveAction |
+	theParanthesesMarker := BrTextInvisibleMarkerAttribute new.
+	aText
+		attribute: theParanthesesMarker
+		from: aLeftIndex
+		to: aRightIndex.
+
+	cursorEnterAction := [ :aTextEditor | 
+		aTextEditor text
+			findAttribute: theParanthesesMarker
+			indicesDo: [ :aParanthesesStart :aParanthesesEnd | 
+				aTextEditor text
+					attribute: (GtPharoParenthesesHighlightAttribute
+							paint: BrGlamorousColors neutralBackgroundColor)
+					from: aParanthesesStart
+					to: aParanthesesEnd ] ].
+
+	cursorLeaveAction := [ :aTextEditor | 
+		aTextEditor text
+			findAttribute: theParanthesesMarker
+			indicesDo: [ :aParanthesesStart :aParanthesesEnd | 
+				(aTextEditor text from: aParanthesesStart to: aParanthesesEnd)
+					clearAttributesOfClass: GtPharoParenthesesHighlightAttribute ] ].
+
+	(aText from: aLeftIndex to: aLeftIndex)
+		onCursorEnter: cursorEnterAction
+		leave: cursorLeaveAction.
+
+	(aText from: aRightIndex to: aRightIndex)
+		onCursorEnter: cursorEnterAction
+		leave: cursorLeaveAction
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> parenthesesColorAt: anIndex [
+	| colors |
+	colors := self parenthesesColors.
+	^ colors at: (anIndex - 1) \\ colors size + 1
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> parenthesesColors [
+	| colors |
+	colors := BrGlamorousColors distinctTenStrongColors allButFirst allButLast
+			collect: [ :each | each twiceDarker ].
+	^ colors
+]

--- a/src/Gt4beam/BeamStylerUtilities.class.st
+++ b/src/Gt4beam/BeamStylerUtilities.class.st
@@ -62,6 +62,21 @@ BeamStylerUtilities class >> highlightParenthesesLeft: aLeftIndex right: aRightI
 ]
 
 { #category : #'*Gt4beam' }
+BeamStylerUtilities class >> keywords [
+	^ {'defmodule'.
+		'def'.
+		'defview'.
+		'defmacro'.
+		'defp'.
+		'defexample'.
+		'use'.
+		'alias'.
+		'typedstruct'.
+		'do'.
+		'end'}
+]
+
+{ #category : #'*Gt4beam' }
 BeamStylerUtilities class >> parenthesesColorAt: anIndex [
 	| colors |
 	colors := self parenthesesColors.

--- a/src/Gt4beam/BeamStylerUtilities.extension.st
+++ b/src/Gt4beam/BeamStylerUtilities.extension.st
@@ -1,0 +1,73 @@
+Extension { #name : #BeamStylerUtilities }
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> colorAndHighlightParenthesesLeft: aLeftIndex right: aRightIndex atNestingLevel: aNestingLevel inText: aText leftLength: aLength [
+	self
+		highlightParenthesesLeft: aLeftIndex
+		right: aRightIndex
+		inText: aText.
+	self
+		colorParenthesesLeft: aLeftIndex
+		right: aRightIndex
+		atNestingLevel: aNestingLevel
+		inText: aText
+		leftLength: aLength
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> colorParenthesesLeft: aLeftIndex right: aRightIndex atNestingLevel: aNestingLevel inText: aText leftLength: aLength [
+	| color |
+	color := self parenthesesColorAt: aNestingLevel.
+	(aText from: aLeftIndex to: aLeftIndex + aLength) foreground: color.
+	(aText from: aRightIndex to: aRightIndex) foreground: color
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> highlightParenthesesLeft: aLeftIndex right: aRightIndex inText: aText [
+	| theParanthesesMarker cursorEnterAction cursorLeaveAction |
+	theParanthesesMarker := BrTextInvisibleMarkerAttribute new.
+	aText
+		attribute: theParanthesesMarker
+		from: aLeftIndex
+		to: aRightIndex.
+
+	cursorEnterAction := [ :aTextEditor | 
+		aTextEditor text
+			findAttribute: theParanthesesMarker
+			indicesDo: [ :aParanthesesStart :aParanthesesEnd | 
+				aTextEditor text
+					attribute: (GtPharoParenthesesHighlightAttribute
+							paint: BrGlamorousColors neutralBackgroundColor)
+					from: aParanthesesStart
+					to: aParanthesesEnd ] ].
+
+	cursorLeaveAction := [ :aTextEditor | 
+		aTextEditor text
+			findAttribute: theParanthesesMarker
+			indicesDo: [ :aParanthesesStart :aParanthesesEnd | 
+				(aTextEditor text from: aParanthesesStart to: aParanthesesEnd)
+					clearAttributesOfClass: GtPharoParenthesesHighlightAttribute ] ].
+
+	(aText from: aLeftIndex to: aLeftIndex)
+		onCursorEnter: cursorEnterAction
+		leave: cursorLeaveAction.
+
+	(aText from: aRightIndex to: aRightIndex)
+		onCursorEnter: cursorEnterAction
+		leave: cursorLeaveAction
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> parenthesesColorAt: anIndex [
+	| colors |
+	colors := self parenthesesColors.
+	^ colors at: (anIndex - 1) \\ colors size + 1
+]
+
+{ #category : #'*Gt4beam' }
+BeamStylerUtilities class >> parenthesesColors [
+	| colors |
+	colors := BrGlamorousColors distinctTenStrongColors allButFirst allButLast
+			collect: [ :each | each twiceDarker ].
+	^ colors
+]

--- a/src/Gt4beam/BeamStylerUtilities.extension.st
+++ b/src/Gt4beam/BeamStylerUtilities.extension.st
@@ -58,6 +58,21 @@ BeamStylerUtilities class >> highlightParenthesesLeft: aLeftIndex right: aRightI
 ]
 
 { #category : #'*Gt4beam' }
+BeamStylerUtilities class >> keywords [
+	^ {'defmodule'.
+		'def'.
+		'defview'.
+		'defmacro'.
+		'defp'.
+		'defexample'.
+		'use'.
+		'alias'.
+		'typedstruct'.
+		'do'.
+		'end'}
+]
+
+{ #category : #'*Gt4beam' }
 BeamStylerUtilities class >> parenthesesColorAt: anIndex [
 	| colors |
 	colors := self parenthesesColors.

--- a/src/Gt4beam/GtSmaCCParserStyler.extension.st
+++ b/src/Gt4beam/GtSmaCCParserStyler.extension.st
@@ -3,12 +3,32 @@ Extension { #name : #GtSmaCCParserStyler }
 { #category : #'*Gt4beam' }
 GtSmaCCParserStyler class >> elixirStyler: aParserClass [
 	<smaccStyler: #ElixirParser priority: 50>
-	^ (self forParser: aParserClass)
-		stylerRules: {GtSmaCCKeywordTokensStylerRule
+	| specialNodes |
+	specialNodes := {'defmodule'.
+			'def'.
+			'defview'.
+			'use'.
+			'alias'.
+			'typedstruct'.
+			'do'.
+			'end'}
+			collect: [ :aToken | 
+				GtSmaCCTokenValueStylerRule
+					tokenName: aToken
 					styleBlock: [ :styler | 
 						styler
 							bold;
-							foreground: Color purple ].
+							foreground: Color purple ] ].
+	^ (self forParser: aParserClass)
+		stylerRules: {GtSmaCCNodeStylerRule
+					nodeClassName: #ElixirTrueNode
+					styleBlock: [ :styler :node :text | (text from: node startPosition to: node stopPosition) foreground: Color orange ].
+				GtSmaCCNodeStylerRule
+					nodeClassName: #ElixirNilNode
+					styleBlock: [ :styler :node :text | (text from: node startPosition to: node stopPosition) foreground: Color orange ].
+				GtSmaCCNodeStylerRule
+					nodeClassName: #ElixirFalseNode
+					styleBlock: [ :styler :node :text | (text from: node startPosition to: node stopPosition) foreground: Color orange ].
 				GtSmaCCCommentStylerRule
 					styleBlock: [ :styler | styler foreground: Color lightGray ].
 				GtSmaCCNodeStylerRule
@@ -20,39 +40,43 @@ GtSmaCCParserStyler class >> elixirStyler: aParserClass [
 				GtSmaCCNodeStylerRule
 					nodeClassName: #ElixirListNode
 					styleBlock: [ :styler :node :text | 
-						CarpStylerUtilities
+						BeamStylerUtilities
 							colorAndHighlightParenthesesLeft: node startPosition
 							right: node stopPosition
 							atNestingLevel: node listDepth
-							inText: text ].
+							inText: text
+							leftLength: 0 ].
 				GtSmaCCNodeStylerRule
 					nodeClassName: #ElixirMapNode
 					styleBlock: [ :styler :node :text | 
-						CarpStylerUtilities
+						BeamStylerUtilities
 							colorAndHighlightParenthesesLeft: node startPosition
 							right: node stopPosition
 							atNestingLevel: node listDepth
-							inText: text ].
+							inText: text
+							leftLength: 1
+									+ (node struct ifNil: [ 0 ] ifNotNil: [ :aStruct | aStruct source size ]) ].
 				GtSmaCCNodeStylerRule
 					nodeClassName: #ElixirAtomNode
 					styleBlock: [ :styler | styler italic ].
 				GtSmaCCNodeStylerRule
-					nodeClassName: #ElixirDoNode
+					nodeClassName: #ElixirBlockExprNode
 					styleBlock: [ :styler :node :text | 
-						(text from: node module startPosition to: node module stopPosition)
-							foreground: Color orange ].
+						(text
+							from: node call expressions first identifier startPosition
+							to: node call expressions first identifier stopPosition) italic bold ].
 				GtSmaCCNodeStylerRule
-					nodeClassName: #ElixirTrueNode
-					styleBlock: [ :styler :node :text | 
-						(text from: node module startPosition to: node module stopPosition)
-							foreground: Color orange ].
+					nodeClassName: #ElixirDotAliasNode
+					styleBlock: [ :styler | styler bold ].
 				GtSmaCCNodeStylerRule
-					nodeClassName: #ElixirFalseNode
+					nodeClassName: #ElixirDoBlockNode
 					styleBlock: [ :styler :node :text | 
-						(text from: node module startPosition to: node module stopPosition)
-							foreground: Color orange ].
+						BeamStylerUtilities
+							highlightParenthesesLeft: node startPosition
+							right: node stopPosition
+							inText: text ].
 				GtSmaCCNodeVariableStylerRule
 					nodeClassName: #SmaCCErrorNode
 					variableNames: #(dismissedTokens errorToken)
-					styleBlock: [ :styler | styler foreground: Color red ]}
+					styleBlock: [ :styler | styler foreground: Color red ]} , specialNodes
 ]

--- a/src/Gt4beam/GtSmaCCParserStyler.extension.st
+++ b/src/Gt4beam/GtSmaCCParserStyler.extension.st
@@ -4,14 +4,7 @@ Extension { #name : #GtSmaCCParserStyler }
 GtSmaCCParserStyler class >> elixirStyler: aParserClass [
 	<smaccStyler: #ElixirParser priority: 50>
 	| specialNodes |
-	specialNodes := {'defmodule'.
-			'def'.
-			'defview'.
-			'use'.
-			'alias'.
-			'typedstruct'.
-			'do'.
-			'end'}
+	specialNodes := BeamStylerUtilities keywords
 			collect: [ :aToken | 
 				GtSmaCCTokenValueStylerRule
 					tokenName: aToken

--- a/src/Gt4beam/GtSmaCCTokenValueStylerRule.class.st
+++ b/src/Gt4beam/GtSmaCCTokenValueStylerRule.class.st
@@ -1,0 +1,14 @@
+Class {
+	#name : #GtSmaCCTokenValueStylerRule,
+	#superclass : #GtSmaCCTokenStylerRule,
+	#category : #Gt4beam
+}
+
+{ #category : #'as yet unclassified' }
+GtSmaCCTokenValueStylerRule >> initializeForParser: parserClass [
+]
+
+{ #category : #'as yet unclassified' }
+GtSmaCCTokenValueStylerRule >> shouldApplyToToken: aSmaCCToken [
+	^ tokenName = aSmaCCToken source
+]


### PR DESCRIPTION
This PR extends the syntax highlighter with more extensive highlighting as well as region highlighting and list/map color matching based on nesting level.

<img width="1840" height="1191" alt="Bildschirmfoto 2025-10-16 um 20 48 10" src="https://github.com/user-attachments/assets/000f7900-7e41-42c2-b4d7-d4cb046be826" />

Cheers