### PR TITLE
Convert Atom Objects into an Actual Object rather than a Symbol And f…

### DIFF
--- a/src/Gt4beam/BeamAtomObject.class.st
+++ b/src/Gt4beam/BeamAtomObject.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #BeamAtomObject,
+	#superclass : #Object,
+	#instVars : [
+		'symbol'
+	],
+	#category : #'Gt4beam-Serialization'
+}
+
+{ #category : #'as yet unclassified' }
+BeamAtomObject class >> new: aSymbol [
+	^ self new symbol: aSymbol
+]
+
+{ #category : #comparing }
+BeamAtomObject >> = aSymbol [
+	"I should probably do this better"
+
+	self class == aSymbol class ifFalse: [ ^ false ].
+	^ self symbol = aSymbol symbol
+]
+
+{ #category : #comparing }
+BeamAtomObject >> hash [
+	^ self symbol hash hashMultiply
+]
+
+{ #category : #'as yet unclassified' }
+BeamAtomObject >> printOn: aStream [
+	self symbol printOn: aStream
+]
+
+{ #category : #'elixir - resolution' }
+BeamAtomObject >> resolve [
+	^ (symbol at: 1) = (symbol at: 1) asUppercase
+		ifTrue: [ symbol ]
+		ifFalse: [ ':' , symbol ]
+]
+
+{ #category : #accessing }
+BeamAtomObject >> symbol [
+	^ symbol
+]
+
+{ #category : #accessing }
+BeamAtomObject >> symbol: anObject [
+	symbol := anObject
+]

--- a/src/Gt4beam/BeamProxyObject.class.st
+++ b/src/Gt4beam/BeamProxyObject.class.st
@@ -43,7 +43,7 @@ BeamProxyObject >> asList [
 { #category : #'as yet unclassified' }
 BeamProxyObject >> attributeAt: name [
 	^ self
-		evaluateAndWait: 'GtBridge.ObjectRegistry.get_attribute(' , self elixirVar asString , ', :', name, ')'
+		evaluateAndWait: 'GtBridge.ObjectRegistry.get_attribute(' , self elixirVar asString , ',', name resolve, ')'
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Gt4beam/ElixirLinkNeoJsonSerializer.class.st
+++ b/src/Gt4beam/ElixirLinkNeoJsonSerializer.class.st
@@ -22,7 +22,8 @@ ElixirLinkNeoJsonSerializer >> handleElixirSpecificData: anObject [
 	Need to handle __pid__ as well"
 
 	anObject isArray
-		ifTrue: [ (anObject at: 1) = '__atom__' ifTrue: [ ^ (anObject at: 2) asSymbol ].
+		ifTrue: [ (anObject at: 1) = '__atom__'
+				ifTrue: [ ^ BeamAtomObject new: (anObject at: 2) asSymbol ].
 			(anObject at: 1) = '__base64__'
 				ifTrue: [ ^ ZnBase64Encoder new decode: (anObject at: 2) ] ].
 	^ anObject

--- a/src/Gt4beam/GtBeamColumnedTreeViewDeclaration.class.st
+++ b/src/Gt4beam/GtBeamColumnedTreeViewDeclaration.class.st
@@ -12,11 +12,14 @@ GtBeamColumnedTreeViewDeclaration class >> remoteName [
 { #category : #'as yet unclassified' }
 GtBeamColumnedTreeViewDeclaration >> treatView: view [
 	view
-		items: [ (self rawData attributeAt: #items) asList ];
-		children: [ :item | (item attributeAt: #children) asList ].
+		items: [ (self rawData attributeAt: (BeamAtomObject new: #items)) asList ];
+		children: [ :item | (item attributeAt: (BeamAtomObject new: #children)) asList ].
 
-	(self rawData attributeAt: #columns) asList
-		withIndexDo: [ :aColumn :anIndex | view column: (aColumn attributeAt: #title) text: [ :item | (item attributeAt: #values) asList at: anIndex ] ]
+	(self rawData attributeAt: (BeamAtomObject new: #columns)) asList
+		withIndexDo: [ :aColumn :anIndex | 
+			view
+				column: (aColumn attributeAt: #title)
+				text: [ :item | (item attributeAt: (BeamAtomObject new: #values)) asList at: anIndex ] ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Gt4beam/GtBeamListViewDeclaration.class.st
+++ b/src/Gt4beam/GtBeamListViewDeclaration.class.st
@@ -11,7 +11,8 @@ GtBeamListViewDeclaration class >> remoteName [
 
 { #category : #'as yet unclassified' }
 GtBeamListViewDeclaration >> treatView: aView [
-	aView items: [ (self rawData attributeAt: #items) asList ]
+	aView
+		items: [ (self rawData attributeAt: (BeamAtomObject new: #items)) asList ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Gt4beam/GtBeamTextEditorViewDeclaration.class.st
+++ b/src/Gt4beam/GtBeamTextEditorViewDeclaration.class.st
@@ -11,7 +11,7 @@ GtBeamTextEditorViewDeclaration class >> remoteName [
 
 { #category : #'as yet unclassified' }
 GtBeamTextEditorViewDeclaration >> treatView: view [
-view  text: [ self rawData attributeAt: #string ]
+	view text: [ self rawData attributeAt: (BeamAtomObject new: #string) ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Gt4beam/GtBeamViewDeclaration.class.st
+++ b/src/Gt4beam/GtBeamViewDeclaration.class.st
@@ -11,7 +11,7 @@ Class {
 GtBeamViewDeclaration class >> fromRawData: aData [
 	self
 		allSubclassesDo: [ :aSubclass | 
-			aSubclass remoteName = (aData attributeAt: #viewName)
+			aSubclass remoteName = (aData attributeAt: (BeamAtomObject new: #viewName))
 				ifTrue: [ ^ aSubclass new rawData: aData ] ].
 
 	^ self error: 'Unknown view'
@@ -26,13 +26,13 @@ GtBeamViewDeclaration class >> remoteName [
 GtBeamViewDeclaration >> asView [
 	| view |
 	view := GtPhlowView empty perform: self viewName.
-	
+
 	view
-				title: (self rawData attributeAt: #title);
-				priority: (self rawData attributeAt: #priority).
-				
+		title: (self rawData attributeAt: (BeamAtomObject new: #title));
+		priority: (self rawData attributeAt:  (BeamAtomObject new: #priority)).
+
 	self treatView: view.
-	
+
 	^ view
 ]
 


### PR DESCRIPTION
…ix Map view

This means we can have cystom views on Atoms.

Further a Map view was broken, I.E. if you had

%{Foo => 3},

The GT view would fail. This is true for any map that isn't stricly lower case atom based